### PR TITLE
Fix: Corrected undefined variable in print_results method

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ class WebCrawler:
         if results:
             print("Search results:")
             for result in results:
-                print(f"- {undefined_variable}")
+                print(f"- {result}")  #changed result variable
         else:
             print("No results found.")
 


### PR DESCRIPTION
Fixed the bug in `print_results(results)` function by changing the initial `undefined_variable` to `result` variable in the loop. This will result in printing each search result as we are a running a for each loop.