### PR TITLE
Fix: Corrected logic in search function to return matching pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ class WebCrawler:
     def search(self, keyword):
         results = []
         for url, text in self.index.items():
-            if keyword.lower() not in text.lower():
+            if keyword.lower() in text.lower():  #changed if condition from 'not in' to 'in' 
                 results.append(url)
         return results
 


### PR DESCRIPTION
The initial bug added URLs which doesn't contained the keyword. So changing the line 34 from `if keyword.lower() not in text.lower():` to `if keyword.lower() in text.lower(): ` would add the URLs which contain the keyword. 